### PR TITLE
Add user identity model and update whoami endpoint

### DIFF
--- a/intellioptics/client.py
+++ b/intellioptics/client.py
@@ -1,7 +1,7 @@
 import os, time
 from typing import Optional, Union, IO, List
 from .errors import ApiTokenError
-from .models import Detector, ImageQuery, QueryResult
+from .models import Detector, ImageQuery, QueryResult, UserIdentity
 from ._http import HttpClient
 from ._img import to_jpeg_bytes
 
@@ -20,9 +20,9 @@ class IntelliOptics:
         )
 
     # Basic health
-    def whoami(self) -> dict:
-        # Replace with a real identity endpoint when available
-        return self._http.get_json("/v1/health")
+    def whoami(self) -> UserIdentity:
+        data = self._http.get_json("/v1/users/me")
+        return UserIdentity(**data)
 
     # Detectors
     def create_detector(self, name: str, labels: Optional[List[str]] = None) -> Detector:

--- a/intellioptics/models.py
+++ b/intellioptics/models.py
@@ -1,4 +1,8 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+try:
+    from pydantic import ConfigDict
+except ImportError:  # pragma: no cover - Pydantic v1 compatibility
+    ConfigDict = None  # type: ignore
 from typing import Optional, List, Dict, Any
 
 class Detector(BaseModel):
@@ -22,3 +26,17 @@ class QueryResult(BaseModel):
     confidence: Optional[float] = None
     result_type: Optional[str] = None
     extra: Optional[Dict[str, Any]] = None
+
+
+class UserIdentity(BaseModel):
+    id: str
+    email: Optional[str] = None
+    name: Optional[str] = None
+    tenant: Optional[str] = None
+    roles: List[str] = Field(default_factory=list)
+
+    if ConfigDict is not None:  # pragma: no branch
+        model_config = ConfigDict(extra="allow")  # type: ignore[attr-defined]
+    else:  # pragma: no cover - executed on Pydantic v1
+        class Config:
+            extra = "allow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,7 @@ intellioptics = "intellioptics.cli:app"
 [tool.setuptools.packages.find]
 include = ["intellioptics*"]
 exclude = ["backend*", "infra*", "sdk*", "spec*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,36 @@
-from intellioptics.client import IntelliOptics
+import pytest
 
-<<<<<<< HEAD
-def test_sdk_init():
-    client = IntelliOptics(api_token="fake-token")
-    assert client.api_token == "fake-token"
-=======
-def test_init():
-    client = IntelliOptics(api_token="test-token")
-    assert client.api_token == "test-token"
->>>>>>> 5f1bbe5 (Initial commit of IntelliOptics SDK)
+from intellioptics.client import IntelliOptics
+from intellioptics.errors import ApiTokenError
+from intellioptics.models import UserIdentity
+
+
+def test_init_requires_api_token():
+    with pytest.raises(ApiTokenError):
+        IntelliOptics(endpoint="https://api.example.com")
+
+
+def test_whoami_returns_user_identity(monkeypatch):
+    client = IntelliOptics(endpoint="https://api.example.com", api_token="token")
+
+    identity_payload = {
+        "id": "user-123",
+        "email": "user@example.com",
+        "name": "Example User",
+        "tenant": "tenant-789",
+        "roles": ["admin", "user"],
+    }
+    requested_path = {}
+
+    def fake_get_json(path):
+        requested_path["value"] = path
+        return identity_payload
+
+    monkeypatch.setattr(client._http, "get_json", fake_get_json)
+
+    identity = client.whoami()
+
+    assert requested_path["value"] == "/v1/users/me"
+    assert isinstance(identity, UserIdentity)
+    serializer = getattr(identity, "model_dump", identity.dict)
+    assert serializer() == identity_payload


### PR DESCRIPTION
## Summary
- add a `UserIdentity` model that supports additional fields from the identity service while remaining compatible across Pydantic versions
- update `IntelliOptics.whoami()` to call `/v1/users/me` and return a structured `UserIdentity`
- configure pytest to focus on SDK tests and cover the new identity response behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d28fb93990832686f32095598edb38