### PR TITLE
Fix Detector labels default and add test

### DIFF
--- a/intellioptics/models.py
+++ b/intellioptics/models.py
@@ -8,7 +8,7 @@ from typing import Optional, List, Dict, Any
 class Detector(BaseModel):
     id: str
     name: str
-    labels: List[str] = []
+    labels: List[str] = Field(default_factory=list)
 
 class ImageQuery(BaseModel):
     id: str

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,11 @@
+from intellioptics.models import Detector
+
+
+def test_detector_labels_are_independent():
+    first = Detector(id="det-1", name="First")
+    second = Detector(id="det-2", name="Second")
+
+    first.labels.append("alpha")
+
+    assert first.labels == ["alpha"]
+    assert second.labels == []


### PR DESCRIPTION
## Summary
- avoid shared mutable defaults for Detector.labels by using Field(default_factory=list)
- add a regression test ensuring Detector instances have independent label lists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2beb06d1c832685ec1419bf030839