### PR TITLE
Update detector schema to name/labels

### DIFF
--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -27,7 +27,7 @@ io = IntelliOptics(api_token="YOUR_TOKEN")  # or set env vars
 
 print("healthy?", io.health_generated())
 
-det = io.create_detector(name="Widget Presence", mode="BINARY", description="Detect widget")
+det = io.create_detector(name="Widget Presence", labels=["present", "missing"])
 res = io.submit_image_query(detector=det.id, image="image.jpg", wait=5.0, confidence_threshold=0.75)
 
 iq = io.get_image_query(res["id"])

--- a/python-sdk/src/intellioptics/generated/openapi/models/__init__.py
+++ b/python-sdk/src/intellioptics/generated/openapi/models/__init__.py
@@ -4,9 +4,7 @@ from .answer_out import AnswerOut
 from .answer_out_answer import AnswerOutAnswer
 from .body_image_query_v1_image_queries_post import BodyImageQueryV1ImageQueriesPost
 from .detector_create import DetectorCreate
-from .detector_create_mode import DetectorCreateMode
 from .detector_out import DetectorOut
-from .detector_out_mode import DetectorOutMode
 from .feedback_in import FeedbackIn
 from .feedback_in_bboxes_type_0_item import FeedbackInBboxesType0Item
 from .feedback_in_correct_label import FeedbackInCorrectLabel
@@ -19,9 +17,7 @@ __all__ = (
     "AnswerOutAnswer",
     "BodyImageQueryV1ImageQueriesPost",
     "DetectorCreate",
-    "DetectorCreateMode",
     "DetectorOut",
-    "DetectorOutMode",
     "FeedbackIn",
     "FeedbackInBboxesType0Item",
     "FeedbackInCorrectLabel",

--- a/python-sdk/src/intellioptics/generated/openapi/models/detector_create.py
+++ b/python-sdk/src/intellioptics/generated/openapi/models/detector_create.py
@@ -1,89 +1,44 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-
-from ..types import UNSET, Unset
-
-from ..models.detector_create_mode import DetectorCreateMode
-from ..types import UNSET, Unset
-from typing import Union
-
-
-
-
 
 
 T = TypeVar("T", bound="DetectorCreate")
 
 
-
 @_attrs_define
 class DetectorCreate:
-    """ 
-        Attributes:
-            name (str):
-            mode (DetectorCreateMode):
-            query_text (str):
-            threshold (Union[Unset, float]):  Default: 0.75.
-     """
+    """Detector creation payload."""
 
     name: str
-    mode: DetectorCreateMode
-    query_text: str
-    threshold: Union[Unset, float] = 0.75
+    labels: list[str] = _attrs_field(factory=list)
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
-
-
-
-
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
-
-        mode = self.mode.value
-
-        query_text = self.query_text
-
-        threshold = self.threshold
-
+        labels = list(self.labels)
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({
             "name": name,
-            "mode": mode,
-            "query_text": query_text,
+            "labels": labels,
         })
-        if threshold is not UNSET:
-            field_dict["threshold"] = threshold
 
         return field_dict
-
-
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("name")
-
-        mode = DetectorCreateMode(d.pop("mode"))
-
-
-
-
-        query_text = d.pop("query_text")
-
-        threshold = d.pop("threshold", UNSET)
+        labels = list(d.pop("labels", []))
 
         detector_create = cls(
             name=name,
-            mode=mode,
-            query_text=query_text,
-            threshold=threshold,
+            labels=labels,
         )
-
 
         detector_create.additional_properties = d
         return detector_create

--- a/python-sdk/src/intellioptics/generated/openapi/models/detector_create_mode.py
+++ b/python-sdk/src/intellioptics/generated/openapi/models/detector_create_mode.py
@@ -1,9 +1,0 @@
-from enum import Enum
-
-class DetectorCreateMode(str, Enum):
-    BINARY = "binary"
-    COUNT = "count"
-    CUSTOM = "custom"
-
-    def __str__(self) -> str:
-        return str(self.value)

--- a/python-sdk/src/intellioptics/generated/openapi/models/detector_out.py
+++ b/python-sdk/src/intellioptics/generated/openapi/models/detector_out.py
@@ -1,105 +1,49 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-
-from ..types import UNSET, Unset
-
-from ..models.detector_out_mode import DetectorOutMode
-from ..types import UNSET, Unset
-from typing import Union
-
-
-
-
 
 
 T = TypeVar("T", bound="DetectorOut")
 
 
-
 @_attrs_define
 class DetectorOut:
-    """ 
-        Attributes:
-            id (str):
-            name (str):
-            mode (DetectorOutMode):
-            query_text (str):
-            threshold (float):
-            status (Union[Unset, str]):  Default: 'active'.
-     """
+    """Detector representation returned by the API."""
 
     id: str
     name: str
-    mode: DetectorOutMode
-    query_text: str
-    threshold: float
-    status: Union[Unset, str] = 'active'
+    labels: list[str] = _attrs_field(factory=list)
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
-
-
-
-
 
     def to_dict(self) -> dict[str, Any]:
         id = self.id
-
         name = self.name
-
-        mode = self.mode.value
-
-        query_text = self.query_text
-
-        threshold = self.threshold
-
-        status = self.status
-
+        labels = list(self.labels)
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({
             "id": id,
             "name": name,
-            "mode": mode,
-            "query_text": query_text,
-            "threshold": threshold,
+            "labels": labels,
         })
-        if status is not UNSET:
-            field_dict["status"] = status
 
         return field_dict
-
-
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("id")
-
         name = d.pop("name")
-
-        mode = DetectorOutMode(d.pop("mode"))
-
-
-
-
-        query_text = d.pop("query_text")
-
-        threshold = d.pop("threshold")
-
-        status = d.pop("status", UNSET)
+        labels = list(d.pop("labels", []))
 
         detector_out = cls(
             id=id,
             name=name,
-            mode=mode,
-            query_text=query_text,
-            threshold=threshold,
-            status=status,
+            labels=labels,
         )
-
 
         detector_out.additional_properties = d
         return detector_out

--- a/python-sdk/src/intellioptics/generated/openapi/models/detector_out_mode.py
+++ b/python-sdk/src/intellioptics/generated/openapi/models/detector_out_mode.py
@@ -1,9 +1,0 @@
-from enum import Enum
-
-class DetectorOutMode(str, Enum):
-    BINARY = "binary"
-    COUNT = "count"
-    CUSTOM = "custom"
-
-    def __str__(self) -> str:
-        return str(self.value)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -3,6 +3,6 @@ from intellioptics import IntelliOptics
 
 # Example:
 # io = IntelliOptics()  # reads INTELLOPTICS_API_TOKEN & INTELLOPTICS_BASE_URL
-# det = io.create_detector("Door open?", "binary", "Is the door open?", threshold=0.8)
+# det = io.create_detector("Door open?", labels=["open", "closed"])
 # ans = io.ask_image(det.id, "frame.jpg")
 # print(ans.answer, ans.confidence)

--- a/sdk/intellioptics/client.py
+++ b/sdk/intellioptics/client.py
@@ -23,20 +23,16 @@ class IntelliOptics:
         )
 
     # --- Detectors ---
-    def create_detector(self, name: str, mode: str, query_text: str, threshold: float = 0.75) -> Detector:
-        payload = {"name": name, "mode": mode, "query_text": query_text, "threshold": threshold}
+    def create_detector(self, name: str, labels: Optional[list[str]] = None) -> Detector:
+        payload = {"name": name, "labels": labels or []}
         r = self._client.post("/v1/detectors", json=payload); _ok(r)
         d = r.json()
-        return Detector(id=d["id"], name=d["name"], mode=d["mode"],
-                        query_text=d["query_text"], threshold=d["threshold"],
-                        status=d.get("status", "active"))
+        return Detector(id=d["id"], name=d["name"], labels=d.get("labels", []))
 
     def get_detector(self, detector_id: str) -> Detector:
         r = self._client.get(f"/v1/detectors/{detector_id}"); _ok(r)
         d = r.json()
-        return Detector(id=d["id"], name=d["name"], mode=d["mode"],
-                        query_text=d["query_text"], threshold=d["threshold"],
-                        status=d.get("status", "active"))
+        return Detector(id=d["id"], name=d["name"], labels=d.get("labels", []))
 
     # --- Image Queries / Answers ---
     def ask_image(self, detector_id: str, image: bytes | str, wait: bool = True) -> Answer:

--- a/sdk/intellioptics/types.py
+++ b/sdk/intellioptics/types.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal, Optional
 
 AnswerLabel = Literal["YES", "NO", "COUNT", "UNCLEAR"]
@@ -15,7 +15,4 @@ class Answer:
 class Detector:
     id: str
     name: str
-    mode: Literal["binary", "count", "custom"]
-    query_text: str
-    threshold: float
-    status: str = "active"
+    labels: list[str] = field(default_factory=list)

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -340,30 +340,18 @@
             "type": "string",
             "title": "Name"
           },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "binary",
-              "count",
-              "custom"
-            ],
-            "title": "Mode"
-          },
-          "query_text": {
-            "type": "string",
-            "title": "Query Text"
-          },
-          "threshold": {
-            "type": "number",
-            "title": "Threshold",
-            "default": 0.75
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "title": "Labels",
+            "default": []
           }
         },
         "type": "object",
         "required": [
-          "name",
-          "mode",
-          "query_text"
+          "name"
         ],
         "title": "DetectorCreate"
       },
@@ -377,36 +365,19 @@
             "type": "string",
             "title": "Name"
           },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "binary",
-              "count",
-              "custom"
-            ],
-            "title": "Mode"
-          },
-          "query_text": {
-            "type": "string",
-            "title": "Query Text"
-          },
-          "threshold": {
-            "type": "number",
-            "title": "Threshold"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status",
-            "default": "active"
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "title": "Labels",
+            "default": []
           }
         },
         "type": "object",
         "required": [
           "id",
-          "name",
-          "mode",
-          "query_text",
-          "threshold"
+          "name"
         ],
         "title": "DetectorOut"
       },


### PR DESCRIPTION
## Summary
- update the OpenAPI detector schemas to expose only the supported name/labels fields
- align the SDK detector models, client helpers, and documentation with the new payload structure
- refresh the generated Python SDK detector models to match the simplified schema

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2dbffe16883269b0ade7a2b53a712