### PR TITLE
Document Git-based installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,35 @@ pip install intellioptics
 > **Note:** The project declares the following runtime dependencies: `requests`, `pydantic (<3)`,
 > `Pillow`, and `typer`.
 
+### Installing from Git (including Docker builds)
+
+When installing directly from the repository—whether on a workstation or in a Dockerfile—point
+`pip` at the repository root. Earlier iterations of the project kept a `python-sdk/` subdirectory,
+but that folder has been removed; attempting to install via
+`#subdirectory=python-sdk` now fails with `neither 'setup.py' nor 'pyproject.toml' found`.
+
+To install the current SDK straight from GitHub:
+
+```bash
+pip install "intellioptics @ git+https://github.com/thamain1/IntelliOptics.git@main"
+```
+
+Pin to a specific tag or commit when you need a reproducible build:
+
+```bash
+pip install "intellioptics @ git+https://github.com/thamain1/IntelliOptics.git@38533a4c1807583422bdb402599eff5fb81d311d"
+```
+
+In Dockerfiles, a typical snippet looks like:
+
+```dockerfile
+RUN python -m pip install --upgrade pip \
+    && pip install "intellioptics @ git+https://github.com/thamain1/IntelliOptics.git@main"
+```
+
+This ensures `pip` discovers the `pyproject.toml` in the repository root and installs the modern
+package layout.
+
 ## Repository layout
 
 Only the modern SDK that powers the published `intellioptics` package is kept in this repository.


### PR DESCRIPTION
## Summary
- note that the legacy python-sdk subdirectory no longer exists
- add explicit examples for installing the SDK directly from the repository root, including Docker snippets

## Testing
- no tests were run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68ed287affa0832680eca2210d528085